### PR TITLE
option to disable rounding for bottom corners

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -36,7 +36,7 @@ pkgbase = openbox-patched
 	md5sums = b72794996c6a3ad94634727b95f9d204
 	md5sums = 0a11d7149da210a31ef88f8a9c717711
 	md5sums = 5be4554431e555084026631898f167aa
-	md5sums = 3bec0508320653ab33214b3c52bb775e
+	md5sums = b0b642c5d23230c0e4ec0884da769d08
 	md5sums = 4c28a1482a2aeb58415cec39f7f3a694
 
 pkgname = openbox-patched

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 sudo: required
-arch:
+archlinux:
+    packages:
+    - startup-notification
+    - libxml2
+    - libxinerama
+    - libxrandr
+    - libxcursor
+    - pango
+    - imlib2
+    - librsvg
+    - libsm
     script:
       - "makepkg -s"
 script:

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -36,7 +36,7 @@ source=("http://openbox.org/dist/openbox/${_pkgname}-${pkgver}.tar.gz"
 md5sums=('b72794996c6a3ad94634727b95f9d204'
          '0a11d7149da210a31ef88f8a9c717711'
          '5be4554431e555084026631898f167aa'
-         'bafd26f495d40fa92838be1c866b32c9'
+         'b0b642c5d23230c0e4ec0884da769d08'
          '4c28a1482a2aeb58415cec39f7f3a694')
 install="${pkgname}.install"
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ The patch also takes an argument for menu corners.
 
     '<cornerRadius menu="yes">8</cornerRadius>'
 
+The patch also takes an argument for the bottom corners.
+
+    '<cornerRadius bottom="yes">8</cornerRadius>'
+
 
 
 ### Fix out of bounds

--- a/openbox-3.6.2-rounded-corners.patch
+++ b/openbox-3.6.2-rounded-corners.patch
@@ -2,32 +2,35 @@ diff --git a/openbox/config.c b/openbox/config.c
 index dad5d1bf..a387335c 100644
 --- a/openbox/config.c
 +++ b/openbox/config.c
-@@ -48,6 +48,8 @@ StrutPartial config_margins;
+@@ -48,6 +48,9 @@ StrutPartial config_margins;
  gchar   *config_theme;
  gboolean config_theme_keepborder;
  guint    config_theme_window_list_icon_size;
 +guint    config_theme_cornerradius;
 +gboolean config_theme_menuradius;
++gboolean config_theme_bottomradius;
 
  gchar   *config_title_layout;
 
-@@ -719,6 +721,10 @@ static void parse_theme(xmlNodePtr node, gpointer d)
+@@ -719,6 +722,11 @@ static void parse_theme(xmlNodePtr node, gpointer d)
          else if (config_theme_window_list_icon_size > 96)
              config_theme_window_list_icon_size = 96;
      }
 +    if ((n = obt_xml_find_node(node, "cornerRadius"))) {
-+	config_theme_cornerradius = obt_xml_node_int(n);
-+	obt_xml_attr_bool(n, "menu", &config_theme_menuradius);
++        config_theme_cornerradius = obt_xml_node_int(n);
++        obt_xml_attr_bool(n, "menu", &config_theme_menuradius);
++        obt_xml_attr_bool(n, "bottom", &config_theme_bottomradius);
 +    }
 
      for (n = obt_xml_find_node(node, "font");
           n;
-@@ -1098,6 +1104,8 @@ void config_startup(ObtXmlInst *i)
+@@ -1098,6 +1106,9 @@ void config_startup(ObtXmlInst *i)
      config_title_layout = g_strdup("NLIMC");
      config_theme_keepborder = TRUE;
      config_theme_window_list_icon_size = 36;
 +    config_theme_cornerradius = 0;
 +    config_theme_menuradius = TRUE;
++    config_theme_bottomradius = TRUE;
 
      config_font_activewindow = NULL;
      config_font_inactivewindow = NULL;
@@ -35,7 +38,7 @@ diff --git a/openbox/config.h b/openbox/config.h
 index 96a66cf1..5622d059 100644
 --- a/openbox/config.h
 +++ b/openbox/config.h
-@@ -152,6 +152,10 @@ extern gchar *config_title_layout;
+@@ -152,6 +152,12 @@ extern gchar *config_title_layout;
  extern gboolean config_animate_iconify;
  /*! Size of icons in focus switching dialogs */
  extern guint config_theme_window_list_icon_size;
@@ -43,6 +46,8 @@ index 96a66cf1..5622d059 100644
 +extern guint config_theme_cornerradius;
 +/*! Display rounded corners for root and client-list menus */
 +extern gboolean config_theme_menuradius;
++/*! Display rounded corners on the botttom of decorated windows */
++extern gboolean config_theme_bottomradius;
 
  /*! The font for the active window's title */
  extern RrFont *config_font_activewindow;
@@ -50,7 +55,7 @@ diff --git a/openbox/frame.c b/openbox/frame.c
 index 89669726..1539717c 100644
 --- a/openbox/frame.c
 +++ b/openbox/frame.c
-@@ -334,6 +334,51 @@ void frame_adjust_shape(ObFrame *self)
+@@ -334,6 +334,55 @@ void frame_adjust_shape(ObFrame *self)
  #endif
  }
 
@@ -89,11 +94,15 @@ index 89669726..1539717c 100644
 +    XSetForeground(obt_display, shape_gc, 1);
 +    XFillArc(obt_display, mask, shape_gc, 0, 0, dia, dia, 0, 23040);
 +    XFillArc(obt_display, mask, shape_gc, width-dia-1, 0, dia, dia, 0, 23040);
-+    XFillArc(obt_display, mask, shape_gc, 0, height-dia-1, dia, dia, 0, 23040);
-+    XFillArc(obt_display, mask, shape_gc, width-dia-1, height-dia-1, dia, dia,
-+        0, 23040);
++    if (config_theme_bottomradius) {
++        XFillArc(obt_display, mask, shape_gc, 0, height-dia-1, dia, dia, 0, 23040);
++        XFillArc(obt_display, mask, shape_gc, width-dia-1, height-dia-1, dia, dia, 0, 23040);
++    }
 +    XFillRectangle(obt_display, mask, shape_gc, rad, 0, width-dia, height);
-+    XFillRectangle(obt_display, mask, shape_gc, 0, rad, width, height-dia);
++    if (config_theme_bottomradius)
++        XFillRectangle(obt_display, mask, shape_gc, 0, rad, width, height-dia);
++    else
++        XFillRectangle(obt_display, mask, shape_gc, 0, rad, width, height);
 +    XShapeCombineMask(obt_display, window, ShapeBounding, 0-win_attr.border_width, 0-win_attr.border_width, mask, ShapeSet);
 +    XFreePixmap(obt_display, mask);
 +    XFreeGC(obt_display, shape_gc);
@@ -102,7 +111,7 @@ index 89669726..1539717c 100644
  void frame_adjust_area(ObFrame *self, gboolean moved,
                         gboolean resized, gboolean fake)
  {
-@@ -857,7 +902,6 @@ void frame_adjust_area(ObFrame *self, gboolean moved,
+@@ -857,7 +906,6 @@ void frame_adjust_area(ObFrame *self, gboolean moved,
 
          if (resized) {
              self->need_render = TRUE;
@@ -110,17 +119,17 @@ index 89669726..1539717c 100644
              frame_adjust_shape(self);
          }
 
-@@ -884,7 +928,9 @@ void frame_adjust_area(ObFrame *self, gboolean moved,
+@@ -884,7 +932,9 @@ void frame_adjust_area(ObFrame *self, gboolean moved,
      {
          XResizeWindow(obt_display, self->label, self->label_width,
                        ob_rr_theme->label_height);
-+	self->need_render = TRUE;
++        self->need_render = TRUE;
      }
 +    framerender_frame(self);
  }
 
  static void frame_adjust_cursors(ObFrame *self)
-@@ -958,6 +1004,8 @@ void frame_adjust_client_area(ObFrame *self)
+@@ -958,6 +1008,8 @@ void frame_adjust_client_area(ObFrame *self)
      XMoveResizeWindow(obt_display, self->backfront, 0, 0,
                        self->client->area.width,
                        self->client->area.height);


### PR DESCRIPTION
I didn't want the bottom corners of windows to be rounded, as content was sometimes slightly cut off so I added a config option to enable/disable this.

Not sure whether you'll want this change or not, but I figured there might be others who want the same option, so created this pull request anyway.
